### PR TITLE
Add prettier check to format non-python code

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,11 +1,11 @@
 name: Bug Report
 description: Create a report to help us fix broken features
 labels: ["bug"]
-body: 
+body:
   - type: markdown
     attributes:
       value: |
-          Thanks for taking the time to open this issue to help improve PyVista!
+        Thanks for taking the time to open this issue to help improve PyVista!
   - type: textarea
     id: what-happened
     attributes:
@@ -16,7 +16,7 @@ body:
       placeholder: Tell us what you see!
       value: "I found a bug!"
     validations:
-      required: true  
+      required: true
   - type: textarea
     id: reproduce
     attributes:
@@ -41,11 +41,11 @@ body:
         import pyvista as pv
         print(pv.Report())
         ```
-      render: shell      
+      render: shell
     validations:
       required: true
   - type: textarea
     id: screenshots
     attributes:
       label: Screenshots
-      description: If applicable, please add screenshots to the text box below 
+      description: If applicable, please add screenshots to the text box below

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,11 +1,11 @@
 name: Feature Request
 description: Request that a feature be added to PyVista
 labels: ["feature-request"]
-body: 
+body:
   - type: markdown
     attributes:
       value: |
-          Thanks for taking the time to open this issue to help improve PyVista!
+        Thanks for taking the time to open this issue to help improve PyVista!
   - type: textarea
     id: feature-details
     attributes:

--- a/.github/ISSUE_TEMPLATE/maintenance-request.yml
+++ b/.github/ISSUE_TEMPLATE/maintenance-request.yml
@@ -1,11 +1,11 @@
 name: Maintenance Request
 description: Request general maintenance to code, CI, deployment, or otherwise
 labels: ["maintenance"]
-body: 
+body:
   - type: markdown
     attributes:
       value: |
-          Thanks for taking the time to open this issue to help improve PyVista!
+        Thanks for taking the time to open this issue to help improve PyVista!
   - type: textarea
     id: maintenance-request
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,11 @@
 
 <!-- Please insert a high-level description of this pull request here. -->
 
-<!-- Be sure to link other PRs or issues that relate to this PR here. --> 
+<!-- Be sure to link other PRs or issues that relate to this PR here. -->
 
 <!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->
-
 
 ### Details
 
 - < feature1 or bug1 description >
 - < feature2 or bug2 description >
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: "3.10"
       - name: Get Job URL
         uses: Tiryoh/gha-jobid-action@v1
         id: jobs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,7 @@
 name: pyvista-doc-tutorial-update
 on:
   schedule:
-    - cron:  '0 1 * * *'
+    - cron: "0 1 * * *"
   push:
     branches:
       - main
@@ -12,81 +12,81 @@ jobs:
   script:
     runs-on: ubuntu-20.04
     steps:
-    - name: Setup Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.9
-    - name: Get Job URL
-      uses: Tiryoh/gha-jobid-action@v1
-      id: jobs
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        job_name: script
-    - name: Checkout with submodule
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        repository: pyvista/pyvista-tutorial-translations
-        submodules: true
-        path: pyvista-tutorial-translations
-    - name: Checkout other repo
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: 'gh-pages'
-        path: pyvista-tutorial-ja
-    - name: Setup SSH
-      uses: MrSquaare/ssh-setup-action@v3
-      with:
-        host: github.com
-        private-key: ${{ secrets.SSH_PRIVATE_KEY }}
-    - name: install
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends python3-setuptools
-        sudo apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb ffmpeg
-        sudo apt-get install -y --no-install-recommends python3-venv
-        sudo apt-get install -y --no-install-recommends libgl1-mesa-glx
-        sudo apt-get install -y --no-install-recommends python3-tk pandoc
-        sudo apt-get install -y --no-install-recommends libgeos-dev
-        pip install -U pip setuptools wheel
-        cd pyvista-tutorial-translations
-        git submodule update --remote
-        pip install -r ./requirements.txt
-        pip install -r pyvista-tutorial/requirements_docs.txt
-        cd ../
-    - name: build
-      env:
-        JOB_ID: ${{ steps.jobs.outputs.job_id }}
-        HTML_URL: ${{ steps.jobs.outputs.html_url }}
-      run: |
-        cd pyvista-tutorial-translations
-        set -x
-        export DISPLAY=:99.0
-        export PYVISTA_OFF_SCREEN=True
-        Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
-        sleep 3
-        set +x
-        git submodule update --remote
-        cd pyvista-tutorial
-        make -C doc html SPHINXOPTS="-w build_errors.txt -N -D language=ja -D locale_dirs='../../../locale'"
-        cd ../
-        cd ../
-    - name: commit
-      if: contains(github.ref, 'main')
-      env:
-        JOB_ID: ${{ steps.jobs.outputs.job_id }}
-        HTML_URL: ${{ steps.jobs.outputs.html_url }}
-      run: |
-        cd pyvista-tutorial-ja
-        git checkout gh-pages
-        git rm -rf *
-        mv ../pyvista-tutorial-translations/pyvista-tutorial/doc/build/html/* .
-        touch .nojekyll
-        git config --global user.email $GITHUB_REPOSITORY
-        git config --global user.name $GITHUB_REPOSITORY
-        git add .
-        git commit --allow-empty -m "[ci skip] $JOB_ID
-        $HTML_URL"
-        git push origin gh-pages
-        cd ../
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+      - name: Get Job URL
+        uses: Tiryoh/gha-jobid-action@v1
+        id: jobs
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          job_name: script
+      - name: Checkout with submodule
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          repository: pyvista/pyvista-tutorial-translations
+          submodules: true
+          path: pyvista-tutorial-translations
+      - name: Checkout other repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: "gh-pages"
+          path: pyvista-tutorial-ja
+      - name: Setup SSH
+        uses: MrSquaare/ssh-setup-action@v3
+        with:
+          host: github.com
+          private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: install
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends python3-setuptools
+          sudo apt-get install -y --no-install-recommends libgl1-mesa-dev xvfb ffmpeg
+          sudo apt-get install -y --no-install-recommends python3-venv
+          sudo apt-get install -y --no-install-recommends libgl1-mesa-glx
+          sudo apt-get install -y --no-install-recommends python3-tk pandoc
+          sudo apt-get install -y --no-install-recommends libgeos-dev
+          pip install -U pip setuptools wheel
+          cd pyvista-tutorial-translations
+          git submodule update --remote
+          pip install -r ./requirements.txt
+          pip install -r pyvista-tutorial/requirements_docs.txt
+          cd ../
+      - name: build
+        env:
+          JOB_ID: ${{ steps.jobs.outputs.job_id }}
+          HTML_URL: ${{ steps.jobs.outputs.html_url }}
+        run: |
+          cd pyvista-tutorial-translations
+          set -x
+          export DISPLAY=:99.0
+          export PYVISTA_OFF_SCREEN=True
+          Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          sleep 3
+          set +x
+          git submodule update --remote
+          cd pyvista-tutorial
+          make -C doc html SPHINXOPTS="-w build_errors.txt -N -D language=ja -D locale_dirs='../../../locale'"
+          cd ../
+          cd ../
+      - name: commit
+        if: contains(github.ref, 'main')
+        env:
+          JOB_ID: ${{ steps.jobs.outputs.job_id }}
+          HTML_URL: ${{ steps.jobs.outputs.html_url }}
+        run: |
+          cd pyvista-tutorial-ja
+          git checkout gh-pages
+          git rm -rf *
+          mv ../pyvista-tutorial-translations/pyvista-tutorial/doc/build/html/* .
+          touch .nojekyll
+          git config --global user.email $GITHUB_REPOSITORY
+          git config --global user.name $GITHUB_REPOSITORY
+          git add .
+          git commit --allow-empty -m "[ci skip] $JOB_ID
+          $HTML_URL"
+          git push origin gh-pages
+          cd ../

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
-- repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.0
-  hooks:
-    - id: check-github-workflows
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: v3.1.0
-  hooks:
-    - id: prettier
-      types_or: [yaml, markdown, html, css, scss, javascript, json]
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.29.0
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.1.0
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,8 @@ repos:
   rev: 0.29.0
   hooks:
     - id: check-github-workflows
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: v3.1.0
+  hooks:
+    - id: prettier
+      types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,3 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
@@ -18,23 +17,23 @@ diverse, inclusive, and healthy community.
 Examples of behavior that contributes to a positive environment for our
 community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
   and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the overall
+- Focusing on what is best not just for us as individuals, but for the overall
   community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or advances of
+- The use of sexualized language or imagery, and sexual attention or advances of
   any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email address,
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
   without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
+- Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
 ## Enforcement Responsibilities

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # pyvista-tutorial-ja
+
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 
 A place where we automatically deploy the PyVista Japanese tutorial.


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The [prettier](https://prettier.io/) tool can format a large number of different file types. Scientific Python Library Development Guide recommends using prettier to format non-python code.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- https://learn.scientific-python.org/development/guides/style/#prettier
